### PR TITLE
Upgrade GitHub Actions to support Node 24 runtime

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6 # Updated from v4 to support Node 24 runtime natively
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6 # Updated from v5 to support Node 24 runtime natively
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5 # Updated from v3 to support Node 24 runtime natively
         with:
           # Upload entire repository
           path: './website'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@v5 # Retained v5 (which supports Node 24) and resolved the trailing typo

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,14 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6 # Updated from v4 to support Node 24 runtime natively
+        uses: actions/checkout@v6
       - name: Setup Pages
-        uses: actions/configure-pages@v6 # Updated from v5 to support Node 24 runtime natively
+        uses: actions/configure-pages@v6
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5 # Updated from v3 to support Node 24 runtime natively
+        uses: actions/upload-pages-artifact@v5
         with:
           # Upload entire repository
           path: './website'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5 # Retained v5 (which supports Node 24) and resolved the trailing typo
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Updated GitHub Actions to use latest versions for Node 24 support.