### PR TITLE
Update "CONTRIBUTING_SPRITE.md" to reference new audit script

### DIFF
--- a/CONTRIBUTING_SPRITES.md
+++ b/CONTRIBUTING_SPRITES.md
@@ -13,15 +13,15 @@ This initial version of the maintenance workflow focuses specifically on:
 
 ### 1. Identifying Missing Sprites
 
-**Script:** `scripts/check_missing_sprites.py`
+**Script:** `scripts/sprite_audit.py`
 
-This script identifies which Pokémon or forms are missing from the `sprites/pokemon/` directory.
+This script identifies missing or invalid sprites in the `sprites/pokemon/` directory.
 
 * **Data Sources:** It references `pokemon.csv` and `pokemon_forms.csv` from the PokéAPI database.
-* **Logic:** It checks for the existence of four primary assets for every entry:
+* **Logic:** It checks the existence and dimensions of four primary assets for every entry:
   * Front (Default & Shiny)
   * Back (Default & Shiny)
-* **Output:** Missing entries are logged in `missing_sprites.csv` to track our progress toward a 100% complete National Dex.
+* **Output:** Issues are logged in `sprite_audit_report.csv` to track our progress toward a 100% complete National Dex.
 
 ### 2. Synchronizing with Smogon
 
@@ -60,6 +60,6 @@ The Smogon source data is community-maintained and contains known inconsistencie
 
 ### How to Use
 
-1. **Check for gaps:** `python scripts/check_missing_sprites.py`
+1. **Check for gaps:** `python scripts/sprite_audit.py`
 2. **Sync Smogon assets:** `python scripts/smogon_download.py`
 3. **Manual Fixes:** Review the downloaded files against the "Known Issues" above and correct names/folders manually before submitting a PR.


### PR DESCRIPTION
Hey there.

I was looking to contribute new sprites. Looking at [`CONTRIBUTING_SPRITES.md`](https://github.com/PokeAPI/sprites/blob/c10459b9b0129eaca5c5d9b1cac65336debb1d08/CONTRIBUTING_SPRITES.md) I figured out it references `check_missing_sprites.py` which was actually later renamed to `sprite_audit.py`. Updated the document accordingly (disclaimer: used AI to also slightly update the script description but this can be reverted if you prefer).